### PR TITLE
Updates Kafka to v3.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ This replicates as well as possible real deployment configurations, where you ha
 
 ## Stack version
 
-  - Zookeeper version: 3.5.9
-  - Kafka version: 2.8.0 (Confluent 6.2.1)
-  - Kafka Schema Registry: Confluent 6.2.1
-  - Kafka Rest Proxy: Confluent 6.2.1
-  - Kafka Connect: Confluent 6.2.1
-  - ksqlDB Server: Confluent 6.2.1
-  - Zoonavigator: 0.8.0
+  - Zookeeper version: 3.6.3 (Confluent 7.0.1)
+  - Kafka version: 3.0.x (Confluent 7.0.1)
+  - Kafka Schema Registry: Confluent 7.0.1
+  - Kafka Rest Proxy: Confluent 7.0.1
+  - Kafka Connect: Confluent 7.0.1
+  - ksqlDB Server: Confluent 7.0.1
+  - Zoonavigator: 1.1.1
 
 For a UI tool to access your local Kafka cluster, use the free version of [Conduktor](https://www.conduktor.io/download)
 
@@ -155,7 +155,7 @@ A: yes. Say you want to change `zoo1` port to `12181` (only relevant lines are s
 A: yes. Say you want to change `kafka1` port to `12345` (only relevant lines are shown). Note only `LISTENER_DOCKER_EXTERNAL` changes:
 ```
   kafka1:
-    image: confluentinc/cp-kafka:6.2.1
+    image: confluentinc/cp-kafka:7.0.1
     hostname: kafka1
     ports:
       - "12345:12345"
@@ -169,7 +169,7 @@ A: yes. This is for testing only!!! Reduce the KAFKA_LOG_SEGMENT_BYTES to 16MB a
 
 ```
   kafka1:
-    image: confluentinc/cp-kafka:6.2.1
+    image: confluentinc/cp-kafka:7.0.1
     ...
     environment:
       ...
@@ -185,7 +185,7 @@ For example, if the IP of your machine is `50.10.2.3`, follow the sample mapping
 
 ```
   kafka1:
-    image: confluentinc/cp-kafka:6.2.1
+    image: confluentinc/cp-kafka:7.0.1
     ...
     environment:
       ...

--- a/full-stack.yml
+++ b/full-stack.yml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
   zoo1:
-    image: confluentinc/cp-zookeeper:6.2.1
+    image: confluentinc/cp-zookeeper:7.0.1
     hostname: zoo1
     container_name: zoo1
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_SERVERS: zoo1:2888:3888
 
   kafka1:
-    image: confluentinc/cp-kafka:6.2.1
+    image: confluentinc/cp-kafka:7.0.1
     hostname: kafka1
     container_name: kafka1
     ports:
@@ -35,7 +35,7 @@ services:
       - zoo1
 
   kafka-schema-registry:
-    image: confluentinc/cp-schema-registry:6.2.1
+    image: confluentinc/cp-schema-registry:7.0.1
     hostname: kafka-schema-registry
     container_name: kafka-schema-registry
     ports:
@@ -50,7 +50,7 @@ services:
 
   
   kafka-rest-proxy:
-    image: confluentinc/cp-kafka-rest:6.2.1
+    image: confluentinc/cp-kafka-rest:7.0.1
     hostname: kafka-rest-proxy
     container_name: kafka-rest-proxy
     ports:
@@ -68,7 +68,7 @@ services:
 
   
   kafka-connect:
-    image: confluentinc/cp-kafka-connect:6.2.1
+    image: confluentinc/cp-kafka-connect:7.0.1
     hostname: kafka-connect
     container_name: kafka-connect
     ports:
@@ -110,7 +110,7 @@ services:
 
   
   ksqldb-server:
-    image: confluentinc/cp-ksqldb-server:6.2.1
+    image: confluentinc/cp-ksqldb-server:7.0.1
     hostname: ksqldb-server
     container_name: ksqldb-server
     ports:
@@ -124,7 +124,7 @@ services:
       - kafka1
 
   zoonavigator:
-    image: elkozmon/zoonavigator:0.8.0
+    image: elkozmon/zoonavigator:1.1.1
     container_name: zoonavigator
     ports:
       - "8004:8000"

--- a/zk-multiple-kafka-multiple-schema-registry.yml
+++ b/zk-multiple-kafka-multiple-schema-registry.yml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
   zoo1:
-    image: confluentinc/cp-zookeeper:6.2.1
+    image: confluentinc/cp-zookeeper:7.0.1
     hostname: zoo1
     container_name: zoo1
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_SERVERS: zoo1:2888:3888;zoo2:2888:3888;zoo3:2888:3888
 
   zoo2:
-    image: confluentinc/cp-zookeeper:6.2.1
+    image: confluentinc/cp-zookeeper:7.0.1
     hostname: zoo2
     container_name: zoo2
     ports:
@@ -24,7 +24,7 @@ services:
       ZOOKEEPER_SERVERS: zoo1:2888:3888;zoo2:2888:3888;zoo3:2888:3888
 
   zoo3:
-    image: confluentinc/cp-zookeeper:6.2.1
+    image: confluentinc/cp-zookeeper:7.0.1
     hostname: zoo3
     container_name: zoo3
     ports:
@@ -36,7 +36,7 @@ services:
 
 
   kafka1:
-    image: confluentinc/cp-kafka:6.2.1
+    image: confluentinc/cp-kafka:7.0.1
     hostname: kafka1
     container_name: kafka1
     ports:
@@ -54,7 +54,7 @@ services:
       - zoo3
 
   kafka2:
-    image: confluentinc/cp-kafka:6.2.1
+    image: confluentinc/cp-kafka:7.0.1
     hostname: kafka2
     container_name: kafka2
     ports:
@@ -72,7 +72,7 @@ services:
       - zoo3
 
   kafka3:
-    image: confluentinc/cp-kafka:6.2.1
+    image: confluentinc/cp-kafka:7.0.1
     hostname: kafka3
     container_name: kafka3
     ports:
@@ -90,7 +90,7 @@ services:
       - zoo3
 
   kafka-schema-registry:
-    image: confluentinc/cp-schema-registry:6.2.1
+    image: confluentinc/cp-schema-registry:7.0.1
     hostname: kafka-schema-registry
     container_name: kafka-schema-registry
     depends_on:

--- a/zk-multiple-kafka-multiple.yml
+++ b/zk-multiple-kafka-multiple.yml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
   zoo1:
-    image: confluentinc/cp-zookeeper:6.2.1
+    image: confluentinc/cp-zookeeper:7.0.1
     hostname: zoo1
     container_name: zoo1
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_SERVERS: zoo1:2888:3888;zoo2:2888:3888;zoo3:2888:3888
 
   zoo2:
-    image: confluentinc/cp-zookeeper:6.2.1
+    image: confluentinc/cp-zookeeper:7.0.1
     hostname: zoo2
     container_name: zoo2
     ports:
@@ -24,7 +24,7 @@ services:
       ZOOKEEPER_SERVERS: zoo1:2888:3888;zoo2:2888:3888;zoo3:2888:3888
 
   zoo3:
-    image: confluentinc/cp-zookeeper:6.2.1
+    image: confluentinc/cp-zookeeper:7.0.1
     hostname: zoo3
     container_name: zoo3
     ports:
@@ -37,7 +37,7 @@ services:
 
 
   kafka1:
-    image: confluentinc/cp-kafka:6.2.1
+    image: confluentinc/cp-kafka:7.0.1
     hostname: kafka1
     container_name: kafka1
     ports:
@@ -55,7 +55,7 @@ services:
       - zoo3
 
   kafka2:
-    image: confluentinc/cp-kafka:6.2.1
+    image: confluentinc/cp-kafka:7.0.1
     hostname: kafka2
     container_name: kafka2
     ports:
@@ -73,7 +73,7 @@ services:
       - zoo3
 
   kafka3:
-    image: confluentinc/cp-kafka:6.2.1
+    image: confluentinc/cp-kafka:7.0.1
     hostname: kafka3
     container_name: kafka3
     ports:

--- a/zk-multiple-kafka-single.yml
+++ b/zk-multiple-kafka-single.yml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
   zoo1:
-    image: confluentinc/cp-zookeeper:6.2.1
+    image: confluentinc/cp-zookeeper:7.0.1
     hostname: zoo1
     container_name: zoo1
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_SERVERS: zoo1:2888:3888;zoo2:2888:3888;zoo3:2888:3888
 
   zoo2:
-    image: confluentinc/cp-zookeeper:6.2.1
+    image: confluentinc/cp-zookeeper:7.0.1
     hostname: zoo2
     container_name: zoo2
     ports:
@@ -24,7 +24,7 @@ services:
       ZOOKEEPER_SERVERS: zoo1:2888:3888;zoo2:2888:3888;zoo3:2888:3888
 
   zoo3:
-    image: confluentinc/cp-zookeeper:6.2.1
+    image: confluentinc/cp-zookeeper:7.0.1
     hostname: zoo3
     container_name: zoo3
     ports:
@@ -36,7 +36,7 @@ services:
 
 
   kafka1:
-    image: confluentinc/cp-kafka:6.2.1
+    image: confluentinc/cp-kafka:7.0.1
     hostname: kafka1
     container_name: kafka1
     ports:

--- a/zk-single-kafka-multiple.yml
+++ b/zk-single-kafka-multiple.yml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
   zoo1:
-    image: confluentinc/cp-zookeeper:6.2.1
+    image: confluentinc/cp-zookeeper:7.0.1
     hostname: zoo1
     container_name: zoo1
     ports:
@@ -14,7 +14,7 @@ services:
 
 
   kafka1:
-    image: confluentinc/cp-kafka:6.2.1
+    image: confluentinc/cp-kafka:7.0.1
     hostname: kafka1
     container_name: kafka1
     ports:
@@ -30,7 +30,7 @@ services:
       - zoo1
 
   kafka2:
-    image: confluentinc/cp-kafka:6.2.1
+    image: confluentinc/cp-kafka:7.0.1
     hostname: kafka2
     container_name: kafka2
     ports:
@@ -47,7 +47,7 @@ services:
 
 
   kafka3:
-    image: confluentinc/cp-kafka:6.2.1
+    image: confluentinc/cp-kafka:7.0.1
     hostname: kafka3
     container_name: kafka3
     ports:

--- a/zk-single-kafka-single.yml
+++ b/zk-single-kafka-single.yml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
   zoo1:
-    image: confluentinc/cp-zookeeper:6.2.1
+    image: confluentinc/cp-zookeeper:7.0.1
     hostname: zoo1
     container_name: zoo1
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_SERVERS: zoo1:2888:3888
 
   kafka1:
-    image: confluentinc/cp-kafka:6.2.1
+    image: confluentinc/cp-kafka:7.0.1
     hostname: kafka1
     container_name: kafka1
     ports:


### PR DESCRIPTION
Update:
 - Kafka from v2.8.0 to v3.0+, via Confluent platform v7.0.1
 - Zookeeper from 3.5.9 to v3.6.3, via Confluent platform v7.0.1 (see https://github.com/confluentinc/common/pull/371)
 - zoonavigator from v0.8.0 to v1.1.1