### PR TITLE
fix: update conduktor service name in full-stack.yml

### DIFF
--- a/full-stack.yml
+++ b/full-stack.yml
@@ -133,7 +133,7 @@ services:
             
   conduktor-platform:
     extends:
-      service: conduktor-platform
+      service: conduktor-console
       file: conduktor.yml
 
 volumes:


### PR DESCRIPTION
Currently running `full-stack.yml` errors out before starting any containers due to a parsing error with the conduktor service. This PR updates `full-stack.yml` so that it references the correct conduktor service name in `conduktor.yml`, which was recently changed in #139. 