### PR TITLE
Update full-stack service

### DIFF
--- a/full-stack.yml
+++ b/full-stack.yml
@@ -133,7 +133,7 @@ services:
             
   conduktor-platform:
     extends:
-      service: conduktor-platform
+      service: conduktor-console
       file: conduktor.yml
 
 volumes:

--- a/full-stack.yml
+++ b/full-stack.yml
@@ -131,7 +131,7 @@ services:
       service: postgresql
       file: conduktor.yml 
             
-  conduktor-platform:
+  conduktor-console:
     extends:
       service: conduktor-console
       file: conduktor.yml

--- a/full-stack.yml
+++ b/full-stack.yml
@@ -127,11 +127,15 @@ services:
       - kafka1
 
   postgresql:
+    hostname: postgresql
+    container_name: postgresql
     extends:
       service: postgresql
       file: conduktor.yml 
             
   conduktor-console:
+    hostname: conduktor-console
+    container_name: conduktor-console
     extends:
       service: conduktor-console
       file: conduktor.yml


### PR DESCRIPTION
Before, we had the error:

> cannot extend service "conduktor-platform" in conduktor.yml: service not found


Because the conduktor.yml service has been modified from `conduktor-platform` to `conduktor-console`