### PR TITLE
Bump confluent stack to 7.9.0

### DIFF
--- a/full-stack.yml
+++ b/full-stack.yml
@@ -1,6 +1,6 @@
 services:
   zoo1:
-    image: confluentinc/cp-zookeeper:7.8.0
+    image: confluentinc/cp-zookeeper:7.9.0
     hostname: zoo1
     container_name: zoo1
     ports:
@@ -11,7 +11,7 @@ services:
       ZOOKEEPER_SERVERS: zoo1:2888:3888
 
   kafka1:
-    image: confluentinc/cp-kafka:7.8.0
+    image: confluentinc/cp-kafka:7.9.0
     hostname: kafka1
     container_name: kafka1
     ports:
@@ -36,7 +36,7 @@ services:
       - zoo1
 
   kafka-schema-registry:
-    image: confluentinc/cp-schema-registry:7.8.0
+    image: confluentinc/cp-schema-registry:7.9.0
     hostname: kafka-schema-registry
     container_name: kafka-schema-registry
     ports:
@@ -51,7 +51,7 @@ services:
 
   
   kafka-rest-proxy:
-    image: confluentinc/cp-kafka-rest:7.8.0
+    image: confluentinc/cp-kafka-rest:7.9.0
     hostname: kafka-rest-proxy
     container_name: kafka-rest-proxy
     ports:
@@ -69,7 +69,7 @@ services:
 
   
   kafka-connect:
-    image: confluentinc/cp-kafka-connect:7.8.0
+    image: confluentinc/cp-kafka-connect:7.9.0
     hostname: kafka-connect
     container_name: kafka-connect
     ports:
@@ -111,7 +111,7 @@ services:
 
   
   ksqldb-server:
-    image: confluentinc/cp-ksqldb-server:7.8.0
+    image: confluentinc/cp-ksqldb-server:7.9.0
     hostname: ksqldb-server
     container_name: ksqldb-server
     ports:

--- a/zk-multiple-kafka-multiple-schema-registry.yml
+++ b/zk-multiple-kafka-multiple-schema-registry.yml
@@ -1,6 +1,6 @@
 services:
   zoo1:
-    image: confluentinc/cp-zookeeper:7.8.0
+    image: confluentinc/cp-zookeeper:7.9.0
     hostname: zoo1
     container_name: zoo1
     ports:
@@ -11,7 +11,7 @@ services:
       ZOOKEEPER_SERVERS: zoo1:2888:3888;zoo2:2888:3888;zoo3:2888:3888
 
   zoo2:
-    image: confluentinc/cp-zookeeper:7.8.0
+    image: confluentinc/cp-zookeeper:7.9.0
     hostname: zoo2
     container_name: zoo2
     ports:
@@ -22,7 +22,7 @@ services:
       ZOOKEEPER_SERVERS: zoo1:2888:3888;zoo2:2888:3888;zoo3:2888:3888
 
   zoo3:
-    image: confluentinc/cp-zookeeper:7.8.0
+    image: confluentinc/cp-zookeeper:7.9.0
     hostname: zoo3
     container_name: zoo3
     ports:
@@ -34,7 +34,7 @@ services:
 
 
   kafka1:
-    image: confluentinc/cp-kafka:7.8.0
+    image: confluentinc/cp-kafka:7.9.0
     hostname: kafka1
     container_name: kafka1
     ports:
@@ -55,7 +55,7 @@ services:
       - zoo3
 
   kafka2:
-    image: confluentinc/cp-kafka:7.8.0
+    image: confluentinc/cp-kafka:7.9.0
     hostname: kafka2
     container_name: kafka2
     ports:
@@ -76,7 +76,7 @@ services:
       - zoo3
 
   kafka3:
-    image: confluentinc/cp-kafka:7.8.0
+    image: confluentinc/cp-kafka:7.9.0
     hostname: kafka3
     container_name: kafka3
     ports:
@@ -97,7 +97,7 @@ services:
       - zoo3
 
   kafka-schema-registry:
-    image: confluentinc/cp-schema-registry:7.8.0
+    image: confluentinc/cp-schema-registry:7.9.0
     hostname: kafka-schema-registry
     container_name: kafka-schema-registry
     depends_on:

--- a/zk-multiple-kafka-multiple.yml
+++ b/zk-multiple-kafka-multiple.yml
@@ -1,6 +1,6 @@
 services:
   zoo1:
-    image: confluentinc/cp-zookeeper:7.8.0
+    image: confluentinc/cp-zookeeper:7.9.0
     hostname: zoo1
     container_name: zoo1
     ports:
@@ -11,7 +11,7 @@ services:
       ZOOKEEPER_SERVERS: zoo1:2888:3888;zoo2:2888:3888;zoo3:2888:3888
 
   zoo2:
-    image: confluentinc/cp-zookeeper:7.8.0
+    image: confluentinc/cp-zookeeper:7.9.0
     hostname: zoo2
     container_name: zoo2
     ports:
@@ -22,7 +22,7 @@ services:
       ZOOKEEPER_SERVERS: zoo1:2888:3888;zoo2:2888:3888;zoo3:2888:3888
 
   zoo3:
-    image: confluentinc/cp-zookeeper:7.8.0
+    image: confluentinc/cp-zookeeper:7.9.0
     hostname: zoo3
     container_name: zoo3
     ports:
@@ -35,7 +35,7 @@ services:
 
 
   kafka1:
-    image: confluentinc/cp-kafka:7.8.0
+    image: confluentinc/cp-kafka:7.9.0
     hostname: kafka1
     container_name: kafka1
     ports:
@@ -56,7 +56,7 @@ services:
       - zoo3
 
   kafka2:
-    image: confluentinc/cp-kafka:7.8.0
+    image: confluentinc/cp-kafka:7.9.0
     hostname: kafka2
     container_name: kafka2
     ports:
@@ -77,7 +77,7 @@ services:
       - zoo3
 
   kafka3:
-    image: confluentinc/cp-kafka:7.8.0
+    image: confluentinc/cp-kafka:7.9.0
     hostname: kafka3
     container_name: kafka3
     ports:

--- a/zk-multiple-kafka-single.yml
+++ b/zk-multiple-kafka-single.yml
@@ -1,6 +1,6 @@
 services:
   zoo1:
-    image: confluentinc/cp-zookeeper:7.8.0
+    image: confluentinc/cp-zookeeper:7.9.0
     hostname: zoo1
     container_name: zoo1
     ports:
@@ -11,7 +11,7 @@ services:
       ZOOKEEPER_SERVERS: zoo1:2888:3888;zoo2:2888:3888;zoo3:2888:3888
 
   zoo2:
-    image: confluentinc/cp-zookeeper:7.8.0
+    image: confluentinc/cp-zookeeper:7.9.0
     hostname: zoo2
     container_name: zoo2
     ports:
@@ -22,7 +22,7 @@ services:
       ZOOKEEPER_SERVERS: zoo1:2888:3888;zoo2:2888:3888;zoo3:2888:3888
 
   zoo3:
-    image: confluentinc/cp-zookeeper:7.8.0
+    image: confluentinc/cp-zookeeper:7.9.0
     hostname: zoo3
     container_name: zoo3
     ports:
@@ -34,7 +34,7 @@ services:
 
 
   kafka1:
-    image: confluentinc/cp-kafka:7.8.0
+    image: confluentinc/cp-kafka:7.9.0
     hostname: kafka1
     container_name: kafka1
     ports:

--- a/zk-single-kafka-multiple.yml
+++ b/zk-single-kafka-multiple.yml
@@ -1,6 +1,6 @@
 services:
   zoo1:
-    image: confluentinc/cp-zookeeper:7.8.0
+    image: confluentinc/cp-zookeeper:7.9.0
     hostname: zoo1
     container_name: zoo1
     ports:
@@ -12,7 +12,7 @@ services:
 
 
   kafka1:
-    image: confluentinc/cp-kafka:7.8.0
+    image: confluentinc/cp-kafka:7.9.0
     hostname: kafka1
     container_name: kafka1
     ports:
@@ -31,7 +31,7 @@ services:
       - zoo1
 
   kafka2:
-    image: confluentinc/cp-kafka:7.8.0
+    image: confluentinc/cp-kafka:7.9.0
     hostname: kafka2
     container_name: kafka2
     ports:
@@ -51,7 +51,7 @@ services:
 
 
   kafka3:
-    image: confluentinc/cp-kafka:7.8.0
+    image: confluentinc/cp-kafka:7.9.0
     hostname: kafka3
     container_name: kafka3
     ports:

--- a/zk-single-kafka-single.yml
+++ b/zk-single-kafka-single.yml
@@ -1,6 +1,6 @@
 services:
   zoo1:
-    image: confluentinc/cp-zookeeper:7.8.0
+    image: confluentinc/cp-zookeeper:7.9.0
     hostname: zoo1
     container_name: zoo1
     ports:
@@ -11,7 +11,7 @@ services:
       ZOOKEEPER_SERVERS: zoo1:2888:3888
 
   kafka1:
-    image: confluentinc/cp-kafka:7.8.0
+    image: confluentinc/cp-kafka:7.9.0
     hostname: kafka1
     container_name: kafka1
     ports:


### PR DESCRIPTION
This pull request updates the Confluent Platform Docker image version from `7.8.0` to `7.9.0` across multiple YAML configuration files.