### PR TITLE
Update Single Console Service to 1.46.2

### DIFF
--- a/conduktor-kafka-single.yml
+++ b/conduktor-kafka-single.yml
@@ -10,7 +10,7 @@ services:
       POSTGRES_PASSWORD: "some_password"
       POSTGRES_HOST_AUTH_METHOD: "scram-sha-256"
   conduktor-console:
-    image: conduktor/conduktor-console:1.36.2
+    image: conduktor/conduktor-console:1.46.2
     ports:
       - "8080:8080"
     volumes:


### PR DESCRIPTION
## Summary
Update conduktor-console image to 1.46.2 in `conduktor-kafka-single.yml`

## Changes
- Updated `conduktor-console` Docker image tag from 1.36.2 to 1.46.2 in `conduktor-kafka-single.yml`

## Motivation
The `conduktor.yml` was already updated to 1.46.2, but `conduktor-kafka-single.yml` was missed. This aligns it with the latest version.